### PR TITLE
Add parameters for calibration

### DIFF
--- a/dvxplorer_ros_driver/include/dvxplorer_ros_driver/driver.h
+++ b/dvxplorer_ros_driver/include/dvxplorer_ros_driver/driver.h
@@ -90,6 +90,7 @@ private:
 	bool master_;
 	std::string device_id_;
 	std::string frame_id_;
+	std::string calibration_file_;
 
 	ros::Time reset_time_;
 

--- a/dvxplorer_ros_driver/include/dvxplorer_ros_driver/driver.h
+++ b/dvxplorer_ros_driver/include/dvxplorer_ros_driver/driver.h
@@ -89,6 +89,7 @@ private:
 	struct caer_dvx_info dvxplorer_info_;
 	bool master_;
 	std::string device_id_;
+	std::string frame_id_;
 
 	ros::Time reset_time_;
 

--- a/dvxplorer_ros_driver/src/driver.cpp
+++ b/dvxplorer_ros_driver/src/driver.cpp
@@ -11,6 +11,7 @@ DvxplorerRosDriver::DvxplorerRosDriver(ros::NodeHandle &nh, ros::NodeHandle nh_p
 	// load parameters
 	nh_private.param<std::string>("serial_number", device_id_, "");
 	nh_private.param<std::string>("frame_id", frame_id_, "");
+	nh_private.param<std::string>("calibration_file", calibration_file_, "");
 	nh_private.param<bool>("master", master_, true);
 	double reset_timestamps_delay;
 	nh_private.param<double>("reset_timestamps_delay", reset_timestamps_delay, -1.0);
@@ -135,7 +136,7 @@ void DvxplorerRosDriver::caerConnect() {
 
 	// camera info handling
 	ros::NodeHandle nh_ns(ns);
-	camera_info_manager_.reset(new camera_info_manager::CameraInfoManager(nh_ns, device_id_));
+	camera_info_manager_.reset(new camera_info_manager::CameraInfoManager(nh_ns, device_id_, calibration_file_));
 
 	// initialize timestamps
 	resetTimestamps();

--- a/dvxplorer_ros_driver/src/driver.cpp
+++ b/dvxplorer_ros_driver/src/driver.cpp
@@ -10,6 +10,7 @@ DvxplorerRosDriver::DvxplorerRosDriver(ros::NodeHandle &nh, ros::NodeHandle nh_p
 	nh_(nh), imu_calibration_running_(false) {
 	// load parameters
 	nh_private.param<std::string>("serial_number", device_id_, "");
+	nh_private.param<std::string>("frame_id", frame_id_, "");
 	nh_private.param<bool>("master", master_, true);
 	double reset_timestamps_delay;
 	nh_private.param<double>("reset_timestamps_delay", reset_timestamps_delay, -1.0);
@@ -306,6 +307,7 @@ void DvxplorerRosDriver::readout() {
 						event_array_msg         = dvs_msgs::EventArrayPtr(new dvs_msgs::EventArray());
 						event_array_msg->height = dvxplorer_info_.dvsSizeY;
 						event_array_msg->width  = dvxplorer_info_.dvsSizeX;
+						event_array_msg->header.frame_id = frame_id_;
 					}
 
 					caerPolarityEventPacket polarity = (caerPolarityEventPacket) packetHeader;
@@ -381,7 +383,7 @@ void DvxplorerRosDriver::readout() {
 							= reset_time_ + ros::Duration().fromNSec(caerIMU6EventGetTimestamp64(event, imu) * 1000);
 
 						// frame
-						msg.header.frame_id = "base_link";
+						msg.header.frame_id = frame_id_;
 
 						// IMU calibration
 						if (imu_calibration_running_) {


### PR DESCRIPTION
Added parameters for publishing a specific `frame_id` in the header as well as pointing the camera manager towards a specific file for intrinsic calibration parameters.